### PR TITLE
画像投稿に関するエラー修正

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -90,6 +90,8 @@ textarea { width: 100%; height: calc( 1.3rem * 4); line-height: 1.3rem; border-r
 
 .reply .reply-from .reply-form-blank { border: 1px solid #000; height: calc( 1.3rem * 4); line-height: 1.3rem; border-radius: 0.2rem; color: #757575 }
 
+.reply .reply-from .fa-image { color: #424242 }
+
 .like form { display: inline-block; }
 
 /*reply, likeボタンのpadding*/

--- a/app/controllers/dreamposts_controller.rb
+++ b/app/controllers/dreamposts_controller.rb
@@ -9,7 +9,7 @@ class DreampostsController < ApplicationController
 
   def create
     @dreampost = current_user.dreamposts.build(dreampost_params)    
-    @user = current_user
+    @user = current_user    
     if @dreampost.save
       redirect_to root_url
     else

--- a/app/views/dreamposts/_reply_to.html.erb
+++ b/app/views/dreamposts/_reply_to.html.erb
@@ -14,8 +14,8 @@
       </div>
     </div>        
     
-      <p><%= dreampost.content %></p>
-    
+      <p class="mb-0"><%= dreampost.content %></p>
+    　<p class="post-img"><%= image_tag dreampost.picture.url if dreampost.picture? %></p>
     </div>
     </div>
 

--- a/app/views/dreamposts/_thread_reply_to.html.erb
+++ b/app/views/dreamposts/_thread_reply_to.html.erb
@@ -15,8 +15,8 @@
       </div>
     </div>        
     
-      <p><%= Dreampost.find_by(id: dreampost.in_reply_to).content %></p>
-    
+      <p class="mb-0"><%= Dreampost.find_by(id: dreampost.in_reply_to).content %></p>
+    　 <p class="post-img mb-3"><%= image_tag Dreampost.find_by(id: dreampost.in_reply_to).picture.url if Dreampost.find_by(id: dreampost.in_reply_to).picture? %></p>
     </div>
     </div>
 

--- a/app/views/shared/_reply_form.html.erb
+++ b/app/views/shared/_reply_form.html.erb
@@ -1,5 +1,5 @@
 <% if logged_in? %>
-<%= form_for(@dreampost) do |f| %>    
+<%= form_for(@dreampost) do |f| %>
   <div class="field">
     <%= f.hidden_field :in_reply_to, value: dreampost.id %>
     <%= f.text_area :content, placeholder: "返信を投稿" %>


### PR DESCRIPTION
画像投稿に関する以下のエラーを修正しました。
・返信モーダル、返信スレッドモーダルに画像が表示されない。
・返信モーダルに画像投稿アイコンが表示されない。