### PR TITLE
[fix]パーシャルの集約

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -16,7 +16,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    @user.picture = "default_user.jpg"
+    @user.picture = "default_user.jpg" # 恐らくこれだと正常にデフォルト画像が登録されていない。
     if @user.save
       @user.send_activation_email
       flash[:info] = "送信されたメールをご確認ください。"

--- a/app/views/dreamposts/_dreampost.html.erb
+++ b/app/views/dreamposts/_dreampost.html.erb
@@ -25,7 +25,6 @@
         </div>
         <% end %>
       </div>
-
       <div class="card-body">
         <div class="card-text">
           <%= render 'dreamposts/thread', dreampost: dreampost %>

--- a/app/views/shared/_replier_img.html.erb
+++ b/app/views/shared/_replier_img.html.erb
@@ -1,6 +1,10 @@
 <% if logged_in? %>
 <a href="<%= user_path(current_user) %>" class="prof-img">
+  <% if current_user.picture.present? %>
   <%= image_tag current_user.picture.url %>
+  <% else %>
+  <%= image_tag 'default_user.jpg' %>
+  <% end %>
 </a>
 <% else %>
 <a class="prof-img">

--- a/app/views/shared/_user_img.html.erb
+++ b/app/views/shared/_user_img.html.erb
@@ -1,3 +1,7 @@
 <a href="<%= user_path(user) %>" class="prof-img">
+  <% if user.picture.present? %>
   <%= image_tag user.picture.url %>
+  <% else %>
+  <%= image_tag 'default_user.jpg' %>
+  <% end %>
 </a>


### PR DESCRIPTION
shared/_user_imgとshared/_replier_imgにuser.picture.present?の分岐を加えました(新規登録ユーザーアクセス時のnilエラー回避のため)。