### PR TITLE
[fix]地図機能の改善

### DIFF
--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -16,7 +16,7 @@
 <script>
   // リストのリンクをクリックした時に地図の位置を動かす
   function OnLinkClick(x, y) {
-    mapInstance.setCenter(new google.maps.LatLng(x+2, y));
+    mapInstance.setCenter(new google.maps.LatLng(x, y));
     mapInstance.setZoom(6);
   }
 </script>


### PR DESCRIPTION
リンクを押した時の地図の位置を、対象の場所の少し下になるようにしていたのを、真ん中に戻しました。