### PR TITLE
[delete]地図リスト投稿機能の追加(取り消し)

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -334,6 +334,17 @@ textarea {
       border-radius: 5px;
     }
   }
+
+  .gmap {
+    height: 400px;
+    border-radius: 5px;
+
+    img {
+      max-width: 100%;
+      height: auto;
+      border-radius: 5px;
+    }
+  }
 }
 
 /*スレッド*/

--- a/app/controllers/dreamposts_controller.rb
+++ b/app/controllers/dreamposts_controller.rb
@@ -34,7 +34,7 @@ class DreampostsController < ApplicationController
   private
 
   def dreampost_params
-    params.require(:dreampost).permit(:content, :picture, :in_reply_to)
+    params.require(:dreampost).permit(:content, :picture, :in_reply_to, :address, :latitude, :longitude)
   end
 
   def correct_user

--- a/app/controllers/dreamposts_controller.rb
+++ b/app/controllers/dreamposts_controller.rb
@@ -10,7 +10,6 @@ class DreampostsController < ApplicationController
     @dreampost = current_user.dreamposts.build(dreampost_params)
     @user = current_user
     if @dreampost.save
-      debugger
       redirect_to root_url
     else
       @feed_items = current_user.feed.page(params[:page]).per(10)

--- a/app/controllers/dreamposts_controller.rb
+++ b/app/controllers/dreamposts_controller.rb
@@ -10,6 +10,7 @@ class DreampostsController < ApplicationController
     @dreampost = current_user.dreamposts.build(dreampost_params)
     @user = current_user
     if @dreampost.save
+      debugger
       redirect_to root_url
     else
       @feed_items = current_user.feed.page(params[:page]).per(10)

--- a/app/views/dreamposts/_dreampost.html.erb
+++ b/app/views/dreamposts/_dreampost.html.erb
@@ -27,10 +27,7 @@
         <%= image_tag dreampost.picture.url if dreampost.picture? %>
       </p>
       <% if dreampost.address? %>
-      <div id="gmap" class="gmap"></div>
-      <%= hidden_field_tag :dreampost_id, dreampost.id, {id: "dreampost-#{dreampost.id}"} %>
-      <%= hidden_field_tag :latitude, dreampost.latitude, {id: "latitude-#{dreampost.id}"} %>
-      <%= hidden_field_tag :longitude, dreampost.longitude, {id: "longitude-#{dreampost.id}" %>
+      <div id="gmap" class="gmap"></div>      
       <% end %>
       <%= render 'dreamposts/reply', dreampost: dreampost %>
       <%= render 'likes/like', dreampost: dreampost %>
@@ -46,8 +43,8 @@
   let map
   let geocoder
   let marker
-  let latitude = $('#latitude').val();
-  let longitude = $('#longitude').val();
+  let latitude = 35.681;
+  let longitude = 139.767;
 
   //地図のデフォルト位置
   function initMap() {

--- a/app/views/dreamposts/_dreampost.html.erb
+++ b/app/views/dreamposts/_dreampost.html.erb
@@ -27,7 +27,7 @@
         <%= image_tag dreampost.picture.url if dreampost.picture? %>
       </p>
       <% if dreampost.address? %>
-      <div id="gmap" class="gmap"></div>      
+      <div id="gmap_<%= dreampost.id %>" class="gmap"></div>      
       <% end %>
       <%= render 'dreamposts/reply', dreampost: dreampost %>
       <%= render 'likes/like', dreampost: dreampost %>
@@ -40,34 +40,15 @@
   async defer></script>
 
 <script>
-  let map
-  let geocoder
-  let marker
-  let latitude = 35.681;
-  let longitude = 139.767;
-
   //地図のデフォルト位置
   function initMap() {
-    geocoder = new google.maps.Geocoder()    
-    mapInstance = new google.maps.Map(document.getElementById('gmap'), {
+    geocoder = new google.maps.Geocoder()
+    mapInstance = new google.maps.Map(document.getElementById(`gmap_${<%= dreampost.id %>}`), {
       center: {
-        lat: latitude,
-        lng: longitude
+        lat: <%= dreampost.latitude %>,
+        lng: <%= dreampost.longitude %>
       },
       zoom: 2
-    });
-
-    pos = new google.maps.LatLng(
-    35.681, //latitude
-    139.767 //longitude
-    );
-    marker = new google.maps.Marker({
-    map: mapInstance,
-    position: pos,
-    icon: {
-    url: ' https://maps.google.com/mapfiles/ms/icons/green-dot.png', //アイコンのURL
-    scaledSize: new google.maps.Size(40, 40) //サイズ
-    }
     });
   }
 </script>

--- a/app/views/dreamposts/_dreampost.html.erb
+++ b/app/views/dreamposts/_dreampost.html.erb
@@ -34,21 +34,3 @@
     </div>
   </div>
 </div>
-
-<script
-  src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.secrets.google_api_key %>&callback=initMap"
-  async defer></script>
-
-<script>
-  //地図のデフォルト位置
-  function initMap() {
-    geocoder = new google.maps.Geocoder()
-    mapInstance = new google.maps.Map(document.getElementById(`gmap_${<%= dreampost.id %>}`), {
-      center: {
-        lat: <%= dreampost.latitude %>,
-        lng: <%= dreampost.longitude %>
-      },
-      zoom: 2
-    });
-  }
-</script>

--- a/app/views/dreamposts/_dreampost.html.erb
+++ b/app/views/dreamposts/_dreampost.html.erb
@@ -26,8 +26,51 @@
       <p class="post-img">
         <%= image_tag dreampost.picture.url if dreampost.picture? %>
       </p>
+      <% if dreampost.address? %>
+      <div id="gmap" class="gmap"></div>
+      <%= hidden_field_tag :dreampost_id, dreampost.id, {id: "dreampost-#{dreampost.id}"} %>
+      <%= hidden_field_tag :latitude, dreampost.latitude, {id: "latitude-#{dreampost.id}"} %>
+      <%= hidden_field_tag :longitude, dreampost.longitude, {id: "longitude-#{dreampost.id}" %>
+      <% end %>
       <%= render 'dreamposts/reply', dreampost: dreampost %>
       <%= render 'likes/like', dreampost: dreampost %>
     </div>
   </div>
 </div>
+
+<script
+  src="https://maps.googleapis.com/maps/api/js?key=<%= Rails.application.secrets.google_api_key %>&callback=initMap"
+  async defer></script>
+
+<script>
+  let map
+  let geocoder
+  let marker
+  let latitude = $('#latitude').val();
+  let longitude = $('#longitude').val();
+
+  //地図のデフォルト位置
+  function initMap() {
+    geocoder = new google.maps.Geocoder()    
+    mapInstance = new google.maps.Map(document.getElementById('gmap'), {
+      center: {
+        lat: latitude,
+        lng: longitude
+      },
+      zoom: 2
+    });
+
+    pos = new google.maps.LatLng(
+    35.681, //latitude
+    139.767 //longitude
+    );
+    marker = new google.maps.Marker({
+    map: mapInstance,
+    position: pos,
+    icon: {
+    url: ' https://maps.google.com/mapfiles/ms/icons/green-dot.png', //アイコンのURL
+    scaledSize: new google.maps.Size(40, 40) //サイズ
+    }
+    });
+  }
+</script>

--- a/app/views/dreamposts/_dreampost.html.erb
+++ b/app/views/dreamposts/_dreampost.html.erb
@@ -20,7 +20,7 @@
       <div class="card-body">
         <div class="card-text">
           <%= render 'dreamposts/thread', dreampost: dreampost %>
-          <span><%= dreampost.content %></span>
+          <span><%= simple_format(dreampost.content) %></span>
         </div>
       </div>
       <p class="post-img">

--- a/app/views/maps/_map.html.erb
+++ b/app/views/maps/_map.html.erb
@@ -3,7 +3,7 @@
     <div class="card-text">
       <div class="d-flex justify-content-between">
         <div><a href="javascript:OnLinkClick(<%= map.latitude %>, <%= map.longitude %>);"><%= map.title %></a></div>
-        <%= render 'shared/dropdown', object: map %>
+        <%= render 'shared/dropdown_map', object: map %>
       </div>
       <div><%= map.comment %></div>
     </div>

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -1,6 +1,9 @@
 <div class="container map">
 <h2 class="text-center">夢の場所</h2>
-<p class="text-center">行ってみたい場所・夢を実現したい場所を<br class="brsp">リストとして登録しましょう!!</p>
+<p class="text-center">
+  行ってみたい場所・夢を実現したい場所を<br class="brsp">リストとして登録しましょう!!
+  <br>タイムラインに投稿してみましょう!!
+</p>
   <div class="row">
     <div class="col-lg-3 mt-3">
     <div class="sticky">   

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -2,7 +2,6 @@
 <h2 class="text-center">夢の場所</h2>
 <p class="text-center">
   行ってみたい場所・夢を実現したい場所を<br class="brsp">リストとして登録しましょう!!
-  <br>タイムラインに投稿してみましょう!!
 </p>
   <div class="row">
     <div class="col-lg-3 mt-3">

--- a/app/views/maps/index.html.erb
+++ b/app/views/maps/index.html.erb
@@ -37,7 +37,7 @@
     </div>
     <div class="col-lg-3 mt-3">
       <div class="maps jscroll">
-      <%= render @maps %>    
+      <%= render @maps %>
       </div>
       </div>
     </div>

--- a/app/views/shared/_dropdown.html.erb
+++ b/app/views/shared/_dropdown.html.erb
@@ -1,9 +1,9 @@
 <div class="dropdown">
-  <button class="btn dropdown-toggle z-2" type="button" id="dropdownMenuButton" , data-toggle="dropdown">
+  <button class="btn dropdown-toggle z-2" type="button" id="dropdownMenuButton", data-toggle="dropdown">
     <i class="fas fa-chevron-down"></i>
   </button>
-  <div class="dropdown-menu dropdown-menu-right">
+  <div class="dropdown-menu dropdown-menu-right">    
     <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
-                                        data: { confirm: "削除してよろしいですか？" } %>
+                                        data: { confirm: "削除してよろしいですか？" } %>    
   </div>
 </div>

--- a/app/views/shared/_dropdown_map.html.erb
+++ b/app/views/shared/_dropdown_map.html.erb
@@ -3,7 +3,7 @@
     <i class="fas fa-chevron-down"></i>
   </button>
   <div class="dropdown-menu dropdown-menu-right">
-    <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + object.comment }), class: 'dropdown-item', method: :post %>
+    <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + "\n" + object.comment }), class: 'dropdown-item', method: :post %>
     <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
                                         data: { confirm: "削除してよろしいですか？" } %>
   </div>

--- a/app/views/shared/_dropdown_map.html.erb
+++ b/app/views/shared/_dropdown_map.html.erb
@@ -4,6 +4,6 @@
   </button>
   <div class="dropdown-menu dropdown-menu-right">
     <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
-                                        data: { confirm: "削除してよろしいですか？" } %>
+                                        data: { confirm: "削除してよろしいですか？" } %> 
   </div>
 </div>

--- a/app/views/shared/_dropdown_map.html.erb
+++ b/app/views/shared/_dropdown_map.html.erb
@@ -4,7 +4,7 @@
   </button>
   <div class="dropdown-menu dropdown-menu-right">
     <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + "\n" + object.comment,
-                                                        picture: object.picture }), class: 'dropdown-item', method: :post %>
+                                                        address: object.address, longitude: object.longitude, latitude: object.latitude }), class: 'dropdown-item', method: :post %>
     <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
                                         data: { confirm: "削除してよろしいですか？" } %>
   </div>

--- a/app/views/shared/_dropdown_map.html.erb
+++ b/app/views/shared/_dropdown_map.html.erb
@@ -3,7 +3,8 @@
     <i class="fas fa-chevron-down"></i>
   </button>
   <div class="dropdown-menu dropdown-menu-right">
-    <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + "\n" + object.comment }), class: 'dropdown-item', method: :post %>
+    <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + "\n" + object.comment,
+                                                        picture: object.picture }), class: 'dropdown-item', method: :post %>
     <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
                                         data: { confirm: "削除してよろしいですか？" } %>
   </div>

--- a/app/views/shared/_dropdown_map.html.erb
+++ b/app/views/shared/_dropdown_map.html.erb
@@ -1,0 +1,10 @@
+<div class="dropdown">
+  <button class="btn dropdown-toggle z-2" type="button" id="dropdownMenuButton" , data-toggle="dropdown">
+    <i class="fas fa-chevron-down"></i>
+  </button>
+  <div class="dropdown-menu dropdown-menu-right">
+    <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + object.comment }), class: 'dropdown-item', method: :post %>
+    <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
+                                        data: { confirm: "削除してよろしいですか？" } %>
+  </div>
+</div>

--- a/app/views/shared/_dropdown_map.html.erb
+++ b/app/views/shared/_dropdown_map.html.erb
@@ -3,8 +3,6 @@
     <i class="fas fa-chevron-down"></i>
   </button>
   <div class="dropdown-menu dropdown-menu-right">
-    <%= link_to "投稿する", dreamposts_path(dreampost: { user_id: current_user, content: object.title + "\n" + object.comment,
-                                                        address: object.address, longitude: object.longitude, latitude: object.latitude }), class: 'dropdown-item', method: :post %>
     <%= link_to "削除する", object, class: 'dropdown-item', method: :delete,
                                         data: { confirm: "削除してよろしいですか？" } %>
   </div>

--- a/db/migrate/20200516210729_add_address_latitude_longitude__to_dreamposts.rb
+++ b/db/migrate/20200516210729_add_address_latitude_longitude__to_dreamposts.rb
@@ -1,0 +1,7 @@
+class AddAddressLatitudeLongitudeToDreamposts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :dreamposts, :address, :string
+    add_column :dreamposts, :latitude, :float
+    add_column :dreamposts, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_06_105135) do
+ActiveRecord::Schema.define(version: 2020_05_16_210729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,9 @@ ActiveRecord::Schema.define(version: 2020_04_06_105135) do
     t.string "picture"
     t.integer "likes_count", default: 0, null: false
     t.integer "in_reply_to", default: 0, null: false
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id", "created_at"], name: "index_dreamposts_on_user_id_and_created_at"
     t.index ["user_id"], name: "index_dreamposts_on_user_id"
   end


### PR DESCRIPTION
「夢の場所」ページのサブタイトルに、投稿できる旨を追加しました。

→5/18
途中まで進めましたが、一旦この機能を取り消します。
マイグレーションファイルは生成したままなので、dreampostカラムにaddress,latitude,longitudeカラムは追加されます。
・maps/index.html.erbの"投稿する"ボタンを削除
・maps/index.html.erbの「タイムラインに投稿してみましょう!!」を削除
・_dreampost.html.erbの地図を表示するコードを削除